### PR TITLE
Make semantic patching of verification more robust

### DIFF
--- a/dev_scripts/semantic-patching/src/main/java/aas_core_works/PatchVerification.java
+++ b/dev_scripts/semantic-patching/src/main/java/aas_core_works/PatchVerification.java
@@ -1,4 +1,4 @@
-
+package aas_core_works;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -78,8 +78,6 @@ public class PatchVerification {
       System.exit(1);
       return;
     }
-
-
 
     VariableDeclarator expectedPatternDecl = null;
     ReturnStmt expectedReturnStmt = null;


### PR DESCRIPTION
We make the semantic patching of verification more robust to future changes by replacing only the individual statements instead of the whole function body.