### PR TITLE
Output javadoc in a separate folder

### DIFF
--- a/.github/workflows/build-doc.yaml
+++ b/.github/workflows/build-doc.yaml
@@ -20,10 +20,10 @@ jobs:
           distribution: 'corretto'
 
       - name: Create javadoc
-        run: javadoc -Xdoclint:none -d doc/javadoc -sourcepath ./src/main/java -subpackages aas_core.aas3_0
+        run: javadoc -Xdoclint:none -d javadoc -sourcepath ./src/main/java -subpackages aas_core.aas3_0
 
       - name: Deploy to gh-pages 🚀
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: doc
+          publish_dir: javadoc


### PR DESCRIPTION
We will use `doc/` to store the hand-written documentation, so we redirect the javadoc to `javadoc/` directory.