### PR TITLE
Ignore missing warnings in Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${javadoc.maven.plugin.version}</version>
                 <configuration>
-                    <doclint>all</doclint>
+                    <doclint>all,-missing</doclint>
                     <overview>
                         ${basedir}/doc/overview.html
                     </overview>


### PR DESCRIPTION
We set the Javadoc to ignore missing documentation directives such as `@return` as they are often meaningless in the context of our library.