### PR TITLE
Use latest aas-core-codegen in dev. scripts

### DIFF
--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
         "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@4d7e59e#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/empwilli/aas-core-codegen@java-gen#egg=aas-core-codegen",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@c414f32#egg=aas-core-codegen",
     ],
     py_modules=["test_codegen"],
 )


### PR DESCRIPTION
We fix the development scripts to use the latest aas-core-codegen so that we can match its version with regular expression in the future with the update script.