### PR TITLE
Publish to gh-pages only on pushes to main

### DIFF
--- a/.github/workflows/build-doc.yaml
+++ b/.github/workflows/build-doc.yaml
@@ -3,8 +3,6 @@ name: Build Documentation
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'corretto'
           cache: maven
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml
+
+      - name: Create javadoc
+        run: mvn javadoc:javadoc


### PR DESCRIPTION
We previously published both on pushes as well as pull requests to main branch, which created conflicts. This patch changes the pipeline so that:
* CI now builds the docs, but does not publish anything, while
* the build-doc workflow builds the docs *and* publishes them.