### PR TITLE
Add `release` maven build profile

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish package
-        run: mvn deploy
+        run: mvn deploy -P release
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
         <!--Note: For Java 8 we need the spotless plugin in version <= 2.30.0 -->
         <spotless.maven.plugin.version>2.30.0</spotless.maven.plugin.version>
         <javadoc.maven.plugin.version>3.6.3</javadoc.maven.plugin.version>
+        <!-- Disable gpg signing per default to allow mvn install and alike w/o gpg setup -->
+        <gpg.skip>true</gpg.skip>
     </properties>
     <dependencies>
         <dependency>
@@ -173,8 +175,18 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <tokenAuth>true</tokenAuth>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <gpg.skip>false</gpg.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
We add the release maven build profile to make signing of the artifacts an optional step in the build process. Until now targets, such as `install`, would attempt to gpg sign the artifacts, failing, if no proper gpg setup is available. To deploy, we now additionally have to select the `release` profile, i.e., `mvn install -P release`.