### PR TITLE
Fix `AUTHORS` for conplement AG

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-Markus Boehm (Markus.Boehm@conplement.de) for Conplement AG
-Tobias Langer (Tobias.Langer@conplement.de) for Conplement AG
+Markus Böhm (Markus.Boehm@conplement.de) for conplement AG
+Tobias Langer (Tobias.Langer@conplement.de) for conplement AG
 Marko Ristin (marko@ristin.ch, marko.ristin@gmail.com, rist@zhaw.ch) for Zurich University of Applied Sciences (ZHAW)
 


### PR DESCRIPTION
Fix `conplement AG` name for proper casing and fix name of Markus Böhm to use an umlaut.