### PR TITLE
Check explicitly for invalid model types

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: 5a9ef8c6
+The revision of aas-core-codegen was: bd310fc2
 """

--- a/dev_scripts/aas_core3/jsonization.py
+++ b/dev_scripts/aas_core3/jsonization.py
@@ -15,6 +15,7 @@ import base64
 import collections.abc
 import sys
 from typing import (
+    cast,
     Any,
     Callable,
     Iterable,
@@ -252,6 +253,58 @@ def _bytes_from_jsonable(
     )
 
 
+def _try_to_cast_to_array_like(
+    jsonable: Jsonable
+) -> Optional[Iterable[Any]]:
+    """
+    Try to cast the ``jsonable`` to something like a JSON array.
+
+    In particular, we explicitly check that the ``jsonable`` is not a mapping, as we
+    do not want to mistake dictionaries (*i.e.* de-serialized JSON objects) for lists.
+
+    >>> assert _try_to_cast_to_array_like(True) is None
+
+    >>> assert _try_to_cast_to_array_like(0) is None
+
+    >>> assert _try_to_cast_to_array_like(2.2) is None
+
+    >>> assert _try_to_cast_to_array_like("hello") is None
+
+    >>> assert _try_to_cast_to_array_like(b"hello") is None
+
+    >>> _try_to_cast_to_array_like([1, 2])
+    [1, 2]
+
+    >>> assert _try_to_cast_to_array_like({"a": 3}) is None
+
+    >>> assert _try_to_cast_to_array_like(collections.OrderedDict()) is None
+
+    >>> _try_to_cast_to_array_like(range(1, 2))
+    range(1, 2)
+
+    >>> _try_to_cast_to_array_like((1, 2))
+    (1, 2)
+
+    >>> assert _try_to_cast_to_array_like({1, 2, 3}) is None
+    """
+    if (
+        
+        not isinstance(jsonable, (str, bytearray, bytes))
+        and hasattr(jsonable, "__iter__")
+        and not hasattr(jsonable, "keys")
+        # NOTE (mristin):
+        # There is no easy way to check for sets as opposed to sequence except
+        # for checking for direct inheritance. A sequence also inherits from
+        # a collection, so both sequences and sets provide ``__contains__`` method.
+        #
+        # See: https://docs.python.org/3/library/collections.abc.html
+        and not isinstance(jsonable, collections.abc.Set)
+    ):
+        return cast(Iterable[Any], jsonable)
+
+    return None
+
+
 def has_semantics_from_jsonable(
         jsonable: Jsonable
 ) -> aas_types.HasSemantics:
@@ -326,15 +379,16 @@ class _SetterForExtension:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -342,7 +396,7 @@ class _SetterForExtension:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -400,15 +454,16 @@ class _SetterForExtension:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -416,7 +471,7 @@ class _SetterForExtension:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -710,15 +765,16 @@ class _SetterForAdministrativeInformation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -726,7 +782,7 @@ class _SetterForAdministrativeInformation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -937,15 +993,16 @@ class _SetterForQualifier:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -953,7 +1010,7 @@ class _SetterForQualifier:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1118,15 +1175,16 @@ class _SetterForAssetAdministrationShell:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -1134,7 +1192,7 @@ class _SetterForAssetAdministrationShell:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1179,15 +1237,16 @@ class _SetterForAssetAdministrationShell:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -1195,7 +1254,7 @@ class _SetterForAssetAdministrationShell:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1214,15 +1273,16 @@ class _SetterForAssetAdministrationShell:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -1230,7 +1290,7 @@ class _SetterForAssetAdministrationShell:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1275,15 +1335,16 @@ class _SetterForAssetAdministrationShell:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -1291,7 +1352,7 @@ class _SetterForAssetAdministrationShell:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1336,15 +1397,16 @@ class _SetterForAssetAdministrationShell:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -1352,7 +1414,7 @@ class _SetterForAssetAdministrationShell:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1380,6 +1442,18 @@ def asset_administration_shell_from_jsonable(
         )
 
     setter = _SetterForAssetAdministrationShell()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'AssetAdministrationShell':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'AssetAdministrationShell', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -1476,15 +1550,16 @@ class _SetterForAssetInformation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.SpecificAssetID
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = specific_asset_id_from_jsonable(
                     jsonable_item
@@ -1492,7 +1567,7 @@ class _SetterForAssetInformation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1732,15 +1807,16 @@ class _SetterForSpecificAssetID:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -1748,7 +1824,7 @@ class _SetterForSpecificAssetID:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1887,15 +1963,16 @@ class _SetterForSubmodel:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -1903,7 +1980,7 @@ class _SetterForSubmodel:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1948,15 +2025,16 @@ class _SetterForSubmodel:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -1964,7 +2042,7 @@ class _SetterForSubmodel:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -1983,15 +2061,16 @@ class _SetterForSubmodel:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -1999,7 +2078,7 @@ class _SetterForSubmodel:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2070,15 +2149,16 @@ class _SetterForSubmodel:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -2086,7 +2166,7 @@ class _SetterForSubmodel:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2105,15 +2185,16 @@ class _SetterForSubmodel:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -2121,7 +2202,7 @@ class _SetterForSubmodel:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2140,15 +2221,16 @@ class _SetterForSubmodel:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -2156,7 +2238,7 @@ class _SetterForSubmodel:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2175,15 +2257,16 @@ class _SetterForSubmodel:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.SubmodelElement
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = submodel_element_from_jsonable(
                     jsonable_item
@@ -2191,7 +2274,7 @@ class _SetterForSubmodel:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2219,6 +2302,18 @@ def submodel_from_jsonable(
         )
 
     setter = _SetterForSubmodel()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Submodel':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Submodel', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -2364,15 +2459,16 @@ class _SetterForRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -2380,7 +2476,7 @@ class _SetterForRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2425,15 +2521,16 @@ class _SetterForRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -2441,7 +2538,7 @@ class _SetterForRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2460,15 +2557,16 @@ class _SetterForRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -2476,7 +2574,7 @@ class _SetterForRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2508,15 +2606,16 @@ class _SetterForRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -2524,7 +2623,7 @@ class _SetterForRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2543,15 +2642,16 @@ class _SetterForRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -2559,7 +2659,7 @@ class _SetterForRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2578,15 +2678,16 @@ class _SetterForRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -2594,7 +2695,7 @@ class _SetterForRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2760,15 +2861,16 @@ class _SetterForSubmodelElementList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -2776,7 +2878,7 @@ class _SetterForSubmodelElementList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2821,15 +2923,16 @@ class _SetterForSubmodelElementList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -2837,7 +2940,7 @@ class _SetterForSubmodelElementList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2856,15 +2959,16 @@ class _SetterForSubmodelElementList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -2872,7 +2976,7 @@ class _SetterForSubmodelElementList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2904,15 +3008,16 @@ class _SetterForSubmodelElementList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -2920,7 +3025,7 @@ class _SetterForSubmodelElementList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2939,15 +3044,16 @@ class _SetterForSubmodelElementList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -2955,7 +3061,7 @@ class _SetterForSubmodelElementList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -2974,15 +3080,16 @@ class _SetterForSubmodelElementList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -2990,7 +3097,7 @@ class _SetterForSubmodelElementList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3061,15 +3168,16 @@ class _SetterForSubmodelElementList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.SubmodelElement
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = submodel_element_from_jsonable(
                     jsonable_item
@@ -3077,7 +3185,7 @@ class _SetterForSubmodelElementList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3105,6 +3213,18 @@ def submodel_element_list_from_jsonable(
         )
 
     setter = _SetterForSubmodelElementList()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'SubmodelElementList':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'SubmodelElementList', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -3178,15 +3298,16 @@ class _SetterForSubmodelElementCollection:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -3194,7 +3315,7 @@ class _SetterForSubmodelElementCollection:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3239,15 +3360,16 @@ class _SetterForSubmodelElementCollection:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -3255,7 +3377,7 @@ class _SetterForSubmodelElementCollection:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3274,15 +3396,16 @@ class _SetterForSubmodelElementCollection:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -3290,7 +3413,7 @@ class _SetterForSubmodelElementCollection:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3322,15 +3445,16 @@ class _SetterForSubmodelElementCollection:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -3338,7 +3462,7 @@ class _SetterForSubmodelElementCollection:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3357,15 +3481,16 @@ class _SetterForSubmodelElementCollection:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -3373,7 +3498,7 @@ class _SetterForSubmodelElementCollection:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3392,15 +3517,16 @@ class _SetterForSubmodelElementCollection:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -3408,7 +3534,7 @@ class _SetterForSubmodelElementCollection:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3427,15 +3553,16 @@ class _SetterForSubmodelElementCollection:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.SubmodelElement
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = submodel_element_from_jsonable(
                     jsonable_item
@@ -3443,7 +3570,7 @@ class _SetterForSubmodelElementCollection:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3471,6 +3598,18 @@ def submodel_element_collection_from_jsonable(
         )
 
     setter = _SetterForSubmodelElementCollection()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'SubmodelElementCollection':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'SubmodelElementCollection', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -3573,15 +3712,16 @@ class _SetterForProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -3589,7 +3729,7 @@ class _SetterForProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3634,15 +3774,16 @@ class _SetterForProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -3650,7 +3791,7 @@ class _SetterForProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3669,15 +3810,16 @@ class _SetterForProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -3685,7 +3827,7 @@ class _SetterForProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3717,15 +3859,16 @@ class _SetterForProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -3733,7 +3876,7 @@ class _SetterForProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3752,15 +3895,16 @@ class _SetterForProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -3768,7 +3912,7 @@ class _SetterForProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3787,15 +3931,16 @@ class _SetterForProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -3803,7 +3948,7 @@ class _SetterForProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -3870,6 +4015,18 @@ def property_from_jsonable(
         )
 
     setter = _SetterForProperty()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Property':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Property', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -3942,15 +4099,16 @@ class _SetterForMultiLanguageProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -3958,7 +4116,7 @@ class _SetterForMultiLanguageProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4003,15 +4161,16 @@ class _SetterForMultiLanguageProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -4019,7 +4178,7 @@ class _SetterForMultiLanguageProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4038,15 +4197,16 @@ class _SetterForMultiLanguageProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -4054,7 +4214,7 @@ class _SetterForMultiLanguageProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4086,15 +4246,16 @@ class _SetterForMultiLanguageProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -4102,7 +4263,7 @@ class _SetterForMultiLanguageProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4121,15 +4282,16 @@ class _SetterForMultiLanguageProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -4137,7 +4299,7 @@ class _SetterForMultiLanguageProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4156,15 +4318,16 @@ class _SetterForMultiLanguageProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -4172,7 +4335,7 @@ class _SetterForMultiLanguageProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4191,15 +4354,16 @@ class _SetterForMultiLanguageProperty:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -4207,7 +4371,7 @@ class _SetterForMultiLanguageProperty:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4248,6 +4412,18 @@ def multi_language_property_from_jsonable(
         )
 
     setter = _SetterForMultiLanguageProperty()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'MultiLanguageProperty':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'MultiLanguageProperty', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -4315,15 +4491,16 @@ class _SetterForRange:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -4331,7 +4508,7 @@ class _SetterForRange:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4376,15 +4553,16 @@ class _SetterForRange:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -4392,7 +4570,7 @@ class _SetterForRange:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4411,15 +4589,16 @@ class _SetterForRange:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -4427,7 +4606,7 @@ class _SetterForRange:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4459,15 +4638,16 @@ class _SetterForRange:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -4475,7 +4655,7 @@ class _SetterForRange:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4494,15 +4674,16 @@ class _SetterForRange:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -4510,7 +4691,7 @@ class _SetterForRange:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4529,15 +4710,16 @@ class _SetterForRange:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -4545,7 +4727,7 @@ class _SetterForRange:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4612,6 +4794,18 @@ def range_from_jsonable(
         )
 
     setter = _SetterForRange()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Range':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Range', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -4683,15 +4877,16 @@ class _SetterForReferenceElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -4699,7 +4894,7 @@ class _SetterForReferenceElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4744,15 +4939,16 @@ class _SetterForReferenceElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -4760,7 +4956,7 @@ class _SetterForReferenceElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4779,15 +4975,16 @@ class _SetterForReferenceElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -4795,7 +4992,7 @@ class _SetterForReferenceElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4827,15 +5024,16 @@ class _SetterForReferenceElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -4843,7 +5041,7 @@ class _SetterForReferenceElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4862,15 +5060,16 @@ class _SetterForReferenceElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -4878,7 +5077,7 @@ class _SetterForReferenceElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4897,15 +5096,16 @@ class _SetterForReferenceElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -4913,7 +5113,7 @@ class _SetterForReferenceElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -4954,6 +5154,18 @@ def reference_element_from_jsonable(
         )
 
     setter = _SetterForReferenceElement()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'ReferenceElement':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'ReferenceElement', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -5019,15 +5231,16 @@ class _SetterForBlob:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -5035,7 +5248,7 @@ class _SetterForBlob:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5080,15 +5293,16 @@ class _SetterForBlob:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -5096,7 +5310,7 @@ class _SetterForBlob:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5115,15 +5329,16 @@ class _SetterForBlob:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -5131,7 +5346,7 @@ class _SetterForBlob:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5163,15 +5378,16 @@ class _SetterForBlob:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -5179,7 +5395,7 @@ class _SetterForBlob:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5198,15 +5414,16 @@ class _SetterForBlob:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -5214,7 +5431,7 @@ class _SetterForBlob:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5233,15 +5450,16 @@ class _SetterForBlob:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -5249,7 +5467,7 @@ class _SetterForBlob:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5303,6 +5521,18 @@ def blob_from_jsonable(
         )
 
     setter = _SetterForBlob()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Blob':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Blob', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -5374,15 +5604,16 @@ class _SetterForFile:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -5390,7 +5621,7 @@ class _SetterForFile:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5435,15 +5666,16 @@ class _SetterForFile:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -5451,7 +5683,7 @@ class _SetterForFile:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5470,15 +5702,16 @@ class _SetterForFile:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -5486,7 +5719,7 @@ class _SetterForFile:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5518,15 +5751,16 @@ class _SetterForFile:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -5534,7 +5768,7 @@ class _SetterForFile:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5553,15 +5787,16 @@ class _SetterForFile:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -5569,7 +5804,7 @@ class _SetterForFile:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5588,15 +5823,16 @@ class _SetterForFile:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -5604,7 +5840,7 @@ class _SetterForFile:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5658,6 +5894,18 @@ def file_from_jsonable(
         )
 
     setter = _SetterForFile()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'File':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'File', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -5730,15 +5978,16 @@ class _SetterForAnnotatedRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -5746,7 +5995,7 @@ class _SetterForAnnotatedRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5791,15 +6040,16 @@ class _SetterForAnnotatedRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -5807,7 +6057,7 @@ class _SetterForAnnotatedRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5826,15 +6076,16 @@ class _SetterForAnnotatedRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -5842,7 +6093,7 @@ class _SetterForAnnotatedRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5874,15 +6125,16 @@ class _SetterForAnnotatedRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -5890,7 +6142,7 @@ class _SetterForAnnotatedRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5909,15 +6161,16 @@ class _SetterForAnnotatedRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -5925,7 +6178,7 @@ class _SetterForAnnotatedRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -5944,15 +6197,16 @@ class _SetterForAnnotatedRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -5960,7 +6214,7 @@ class _SetterForAnnotatedRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6005,15 +6259,16 @@ class _SetterForAnnotatedRelationshipElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.DataElement
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = data_element_from_jsonable(
                     jsonable_item
@@ -6021,7 +6276,7 @@ class _SetterForAnnotatedRelationshipElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6049,6 +6304,18 @@ def annotated_relationship_element_from_jsonable(
         )
 
     setter = _SetterForAnnotatedRelationshipElement()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'AnnotatedRelationshipElement':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'AnnotatedRelationshipElement', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -6128,15 +6395,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -6144,7 +6412,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6189,15 +6457,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -6205,7 +6474,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6224,15 +6493,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -6240,7 +6510,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6272,15 +6542,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -6288,7 +6559,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6307,15 +6578,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -6323,7 +6595,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6342,15 +6614,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -6358,7 +6631,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6377,15 +6650,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.SubmodelElement
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = submodel_element_from_jsonable(
                     jsonable_item
@@ -6393,7 +6667,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6438,15 +6712,16 @@ class _SetterForEntity:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.SpecificAssetID
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = specific_asset_id_from_jsonable(
                     jsonable_item
@@ -6454,7 +6729,7 @@ class _SetterForEntity:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6482,6 +6757,18 @@ def entity_from_jsonable(
         )
 
     setter = _SetterForEntity()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Entity':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Entity', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -6863,15 +7150,16 @@ class _SetterForBasicEventElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -6879,7 +7167,7 @@ class _SetterForBasicEventElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6924,15 +7212,16 @@ class _SetterForBasicEventElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -6940,7 +7229,7 @@ class _SetterForBasicEventElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -6959,15 +7248,16 @@ class _SetterForBasicEventElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -6975,7 +7265,7 @@ class _SetterForBasicEventElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7007,15 +7297,16 @@ class _SetterForBasicEventElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -7023,7 +7314,7 @@ class _SetterForBasicEventElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7042,15 +7333,16 @@ class _SetterForBasicEventElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -7058,7 +7350,7 @@ class _SetterForBasicEventElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7077,15 +7369,16 @@ class _SetterForBasicEventElement:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -7093,7 +7386,7 @@ class _SetterForBasicEventElement:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7226,6 +7519,18 @@ def basic_event_element_from_jsonable(
 
     setter = _SetterForBasicEventElement()
 
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'BasicEventElement':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'BasicEventElement', "
+            f"but got: {model_type!r}"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = (
             _SETTER_MAP_FOR_BASIC_EVENT_ELEMENT.get(key)
@@ -7313,15 +7618,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -7329,7 +7635,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7374,15 +7680,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -7390,7 +7697,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7409,15 +7716,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -7425,7 +7733,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7457,15 +7765,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -7473,7 +7782,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7492,15 +7801,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -7508,7 +7818,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7527,15 +7837,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -7543,7 +7854,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7562,15 +7873,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.OperationVariable
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = operation_variable_from_jsonable(
                     jsonable_item
@@ -7578,7 +7890,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7597,15 +7909,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.OperationVariable
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = operation_variable_from_jsonable(
                     jsonable_item
@@ -7613,7 +7926,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7632,15 +7945,16 @@ class _SetterForOperation:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.OperationVariable
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = operation_variable_from_jsonable(
                     jsonable_item
@@ -7648,7 +7962,7 @@ class _SetterForOperation:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7676,6 +7990,18 @@ def operation_from_jsonable(
         )
 
     setter = _SetterForOperation()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Operation':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Operation', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -7814,15 +8140,16 @@ class _SetterForCapability:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -7830,7 +8157,7 @@ class _SetterForCapability:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7875,15 +8202,16 @@ class _SetterForCapability:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -7891,7 +8219,7 @@ class _SetterForCapability:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7910,15 +8238,16 @@ class _SetterForCapability:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -7926,7 +8255,7 @@ class _SetterForCapability:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7958,15 +8287,16 @@ class _SetterForCapability:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -7974,7 +8304,7 @@ class _SetterForCapability:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -7993,15 +8323,16 @@ class _SetterForCapability:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Qualifier
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = qualifier_from_jsonable(
                     jsonable_item
@@ -8009,7 +8340,7 @@ class _SetterForCapability:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8028,15 +8359,16 @@ class _SetterForCapability:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -8044,7 +8376,7 @@ class _SetterForCapability:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8072,6 +8404,18 @@ def capability_from_jsonable(
         )
 
     setter = _SetterForCapability()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'Capability':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Capability', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -8134,15 +8478,16 @@ class _SetterForConceptDescription:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Extension
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = extension_from_jsonable(
                     jsonable_item
@@ -8150,7 +8495,7 @@ class _SetterForConceptDescription:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8195,15 +8540,16 @@ class _SetterForConceptDescription:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringNameType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_name_type_from_jsonable(
                     jsonable_item
@@ -8211,7 +8557,7 @@ class _SetterForConceptDescription:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8230,15 +8576,16 @@ class _SetterForConceptDescription:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringTextType
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_text_type_from_jsonable(
                     jsonable_item
@@ -8246,7 +8593,7 @@ class _SetterForConceptDescription:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8291,15 +8638,16 @@ class _SetterForConceptDescription:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.EmbeddedDataSpecification
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = embedded_data_specification_from_jsonable(
                     jsonable_item
@@ -8307,7 +8655,7 @@ class _SetterForConceptDescription:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8326,15 +8674,16 @@ class _SetterForConceptDescription:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Reference
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = reference_from_jsonable(
                     jsonable_item
@@ -8342,7 +8691,7 @@ class _SetterForConceptDescription:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8370,6 +8719,18 @@ def concept_description_from_jsonable(
         )
 
     setter = _SetterForConceptDescription()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'ConceptDescription':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'ConceptDescription', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (
@@ -8483,15 +8844,16 @@ class _SetterForReference:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Key
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = key_from_jsonable(
                     jsonable_item
@@ -8499,7 +8861,7 @@ class _SetterForReference:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8954,15 +9316,16 @@ class _SetterForEnvironment:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.AssetAdministrationShell
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = asset_administration_shell_from_jsonable(
                     jsonable_item
@@ -8970,7 +9333,7 @@ class _SetterForEnvironment:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -8989,15 +9352,16 @@ class _SetterForEnvironment:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.Submodel
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = submodel_from_jsonable(
                     jsonable_item
@@ -9005,7 +9369,7 @@ class _SetterForEnvironment:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -9024,15 +9388,16 @@ class _SetterForEnvironment:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.ConceptDescription
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = concept_description_from_jsonable(
                     jsonable_item
@@ -9040,7 +9405,7 @@ class _SetterForEnvironment:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -9492,15 +9857,16 @@ class _SetterForValueList:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.ValueReferencePair
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = value_reference_pair_from_jsonable(
                     jsonable_item
@@ -9508,7 +9874,7 @@ class _SetterForValueList:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -9877,15 +10243,16 @@ class _SetterForDataSpecificationIEC61360:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringPreferredNameTypeIEC61360
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_preferred_name_type_iec_61360_from_jsonable(
                     jsonable_item
@@ -9893,7 +10260,7 @@ class _SetterForDataSpecificationIEC61360:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -9912,15 +10279,16 @@ class _SetterForDataSpecificationIEC61360:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringShortNameTypeIEC61360
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_short_name_type_iec_61360_from_jsonable(
                     jsonable_item
@@ -9928,7 +10296,7 @@ class _SetterForDataSpecificationIEC61360:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -10012,15 +10380,16 @@ class _SetterForDataSpecificationIEC61360:
 
         :param jsonable: input to be parsed
         """
-        if not isinstance(jsonable, collections.abc.Iterable):
+        array_like = _try_to_cast_to_array_like(jsonable)
+        if array_like is None:
             raise DeserializationException(
-                f"Expected an iterable, but got: {type(jsonable)}"
+                f"Expected something array-like, but got: {type(jsonable)}"
             )
 
         items: List[
             aas_types.LangStringDefinitionTypeIEC61360
         ] = []
-        for i, jsonable_item in enumerate(jsonable):
+        for i, jsonable_item in enumerate(array_like):
             try:
                 item = lang_string_definition_type_iec_61360_from_jsonable(
                     jsonable_item
@@ -10028,7 +10397,7 @@ class _SetterForDataSpecificationIEC61360:
             except DeserializationException as exception:
                 exception.path._prepend(
                     IndexSegment(
-                        jsonable,
+                        array_like,
                         i
                     )
                 )
@@ -10108,6 +10477,18 @@ def data_specification_iec_61360_from_jsonable(
         )
 
     setter = _SetterForDataSpecificationIEC61360()
+
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
+    if model_type != 'DataSpecificationIec61360':
+        raise DeserializationException(
+            f"Invalid modelType, expected 'DataSpecificationIec61360', "
+            f"but got: {model_type!r}"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = (

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
         "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@6d5411b#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@5a9ef8c6#egg=aas-core-codegen",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@bd310fc2#egg=aas-core-codegen",
         "lxml",
     ],
     py_modules=["test_codegen"],

--- a/src/main/java/aas_core/aas3_0/jsonization/Jsonization.java
+++ b/src/main/java/aas_core/aas3_0/jsonization/Jsonization.java
@@ -1312,6 +1312,8 @@ public class Jsonization {
       IReference theDerivedFrom = null;
       List<IReference> theSubmodels = null;
 
+      String modelType = null;
+
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
 
@@ -1613,7 +1615,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(AssetAdministrationShell.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("AssetAdministrationShell")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'AssetAdministrationShell', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -1622,6 +1647,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theId == null) {
@@ -2073,6 +2104,8 @@ public class Jsonization {
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       List<ISubmodelElement> theSubmodelElements = null;
 
+      String modelType = null;
+
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
 
@@ -2452,7 +2485,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(Submodel.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("Submodel")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'Submodel', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -2461,6 +2514,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theId == null) {
@@ -2648,6 +2707,8 @@ public class Jsonization {
       List<IReference> theSupplementalSemanticIds = null;
       List<IQualifier> theQualifiers = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -2972,7 +3033,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(RelationshipElement.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("RelationshipElement")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'RelationshipElement', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -2981,6 +3065,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theFirst == null) {
@@ -3057,6 +3147,8 @@ public class Jsonization {
       IReference theSemanticIdListElement = null;
       DataTypeDefXsd theValueTypeListElement = null;
       List<ISubmodelElement> theValue = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -3457,7 +3549,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(SubmodelElementList.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("SubmodelElementList")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'SubmodelElementList', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -3466,6 +3581,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theTypeValueListElement == null) {
@@ -3517,6 +3638,8 @@ public class Jsonization {
       List<IQualifier> theQualifiers = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       List<ISubmodelElement> theValue = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -3849,7 +3972,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(SubmodelElementCollection.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("SubmodelElementCollection")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'SubmodelElementCollection', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -3858,6 +4004,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       return Result.success(
@@ -3960,6 +4112,8 @@ public class Jsonization {
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       String theValue = null;
       IReference theValueId = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -4300,7 +4454,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(Property.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("Property")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'Property', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -4309,6 +4483,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theValueType == null) {
@@ -4358,6 +4538,8 @@ public class Jsonization {
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       List<ILangStringTextType> theValue = null;
       IReference theValueId = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -4705,7 +4887,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(MultiLanguageProperty.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("MultiLanguageProperty")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'MultiLanguageProperty', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -4714,6 +4919,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       return Result.success(
@@ -4757,6 +4968,8 @@ public class Jsonization {
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       String theMin = null;
       String theMax = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -5096,7 +5309,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(Range.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("Range")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'Range', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -5105,6 +5338,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theValueType == null) {
@@ -5153,6 +5392,8 @@ public class Jsonization {
       List<IQualifier> theQualifiers = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       IReference theValue = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -5462,7 +5703,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(ReferenceElement.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("ReferenceElement")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'ReferenceElement', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -5471,6 +5735,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       return Result.success(
@@ -5512,6 +5782,8 @@ public class Jsonization {
       List<IQualifier> theQualifiers = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       byte[] theValue = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -5837,7 +6109,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(Blob.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("Blob")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'Blob', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -5846,6 +6138,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theContentType == null) {
@@ -5894,6 +6192,8 @@ public class Jsonization {
       List<IQualifier> theQualifiers = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       String theValue = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -6219,7 +6519,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(File.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("File")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'File', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -6228,6 +6548,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theContentType == null) {
@@ -6278,6 +6604,8 @@ public class Jsonization {
       List<IQualifier> theQualifiers = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       List<IDataElement> theAnnotations = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -6641,7 +6969,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(AnnotatedRelationshipElement.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("AnnotatedRelationshipElement")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'AnnotatedRelationshipElement', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -6650,6 +7001,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theFirst == null) {
@@ -6706,6 +7063,8 @@ public class Jsonization {
       List<ISubmodelElement> theStatements = null;
       String theGlobalAssetId = null;
       List<ISpecificAssetId> theSpecificAssetIds = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -7114,7 +7473,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(Entity.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("Entity")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'Entity', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -7123,6 +7502,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theEntityType == null) {
@@ -7474,6 +7859,8 @@ public class Jsonization {
       String theLastUpdate = null;
       String theMinInterval = null;
       String theMaxInterval = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -7900,7 +8287,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(BasicEventElement.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("BasicEventElement")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'BasicEventElement', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -7909,6 +8319,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theObserved == null) {
@@ -7975,6 +8391,8 @@ public class Jsonization {
       List<IOperationVariable> theInputVariables = null;
       List<IOperationVariable> theOutputVariables = null;
       List<IOperationVariable> theInoutputVariables = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -8389,7 +8807,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(Operation.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("Operation")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'Operation', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -8398,6 +8836,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       return Result.success(
@@ -8491,6 +8935,8 @@ public class Jsonization {
       List<IReference> theSupplementalSemanticIds = null;
       List<IQualifier> theQualifiers = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -8785,7 +9231,27 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(Capability.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("Capability")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'Capability', " + "but got '" + modelType + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -8794,6 +9260,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       return Result.success(
@@ -8832,6 +9304,8 @@ public class Jsonization {
       IAdministrativeInformation theAdministration = null;
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
       List<IReference> theIsCaseOf = null;
+
+      String modelType = null;
 
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
@@ -9098,7 +9572,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(ConceptDescription.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("ConceptDescription")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'ConceptDescription', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -9107,6 +9604,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (theId == null) {
@@ -10376,6 +10879,8 @@ public class Jsonization {
       String theValue = null;
       ILevelType theLevelType = null;
 
+      String modelType = null;
+
       for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
         Map.Entry<String, JsonNode> currentNode = iterator.next();
 
@@ -10643,7 +11148,30 @@ public class Jsonization {
             }
           case "modelType":
             {
-              continue;
+              if (currentNode.getValue() == null) {
+                final Reporting.Error error =
+                    new Reporting.Error("Expected a model type, but got null");
+                return Result.failure(error);
+              }
+              final Result<? extends String> modelTypeResult =
+                  DeserializeImplementation.tryStringFrom(currentNode.getValue());
+              if (modelTypeResult.isError()) {
+                modelTypeResult.getError().prependSegment(new Reporting.NameSegment("modelType"));
+                return modelTypeResult.castTo(DataSpecificationIec61360.class);
+              }
+              modelType = modelTypeResult.getResult();
+
+              if (!modelType.equals("DataSpecificationIec61360")) {
+                final Reporting.Error error =
+                    new Reporting.Error(
+                        "Expected the model type 'DataSpecificationIec61360', "
+                            + "but got '"
+                            + modelType
+                            + "'");
+                error.prependSegment(new Reporting.NameSegment("modelType"));
+                return Result.failure(error);
+              }
+              break;
             }
           default:
             {
@@ -10652,6 +11180,12 @@ public class Jsonization {
               return Result.failure(error);
             }
         }
+      }
+
+      if (modelType == null) {
+        final Reporting.Error error =
+            new Reporting.Error("Required property \"modelType\" is missing");
+        return Result.failure(error);
       }
 
       if (thePreferredName == null) {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
@@ -1,0 +1,12 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Expected the model type 'AssetAdministrationShell', but got 'aCompletelyInvalidModelType' at: assetAdministrationShells[0].modelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Expected the model type 'ConceptDescription', but got 'aCompletelyInvalidModelType' at: conceptDescriptions[0].modelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
@@ -1,0 +1,30 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "modelType": "aCompletelyInvalidModelType",
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for IDataSpecificationContent: aCompletelyInvalidModelType at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Expected the model type 'Submodel', but got 'aCompletelyInvalidModelType' at: submodels[0].modelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+Unexpected model type for ISubmodelElement: aCompletelyInvalidModelType at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
@@ -1,0 +1,11 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Required property "modelType" is missing at: assetAdministrationShells[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
@@ -1,0 +1,24 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Required property "modelType" is missing at: conceptDescriptions[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
@@ -1,0 +1,29 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Required property "modelType" is missing at: submodels[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+Expected a model type, but none is present at: submodels[0].submodelElements[0]


### PR DESCRIPTION
We explicitly check during the JSON de-serialization that model types correspond to the expected model types. We need to be particularly careful with concrete classes without descendants with a mandatory modelType, as they do not necessarily require a model type for de-serialization, but the specs mandate it for reasons of backward compatibility.

The code corresponds to aas-core-codegen 41badc20, and the test data corresponds to aas-core3.0-testgen 9e523511c.

This is related to the issue aas-core3.0-python #32, which discovered the problematic in the first place.