### PR TITLE
Update to aas-core-meta, codegen, testgen f9cbdb3, b14237b, 5a705a0b

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: 0f7345e
+The revision of aas-core-codegen was: b14237b
 """

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -3426,21 +3426,21 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.value is not None)
-                    and (
-                        (
-                            that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
-                            or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
-                        )
-                    )
+                    that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
+                    or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
                 )
             )
             or (
                 (
                     (that.value_type_list_element is not None)
-                    and properties_or_ranges_have_value_type(
-                        that.value,
-                        that.value_type_list_element
+                    and (
+                        (
+                            (that.value is None)
+                            or properties_or_ranges_have_value_type(
+                                that.value,
+                                that.value_type_list_element
+                            )
+                        )
                     )
                 )
             )

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -28,8 +28,8 @@ setup(
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@31d6afd#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@0f7345e#egg=aas-core-codegen",
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f9cbdb3#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@b14237b#egg=aas-core-codegen",
         "lxml",
     ],
     py_modules=["test_codegen"],

--- a/src/main/java/aas_core/aas3_0/verification/Verification.java
+++ b/src/main/java/aas_core/aas3_0/verification/Verification.java
@@ -3892,12 +3892,13 @@ public class Verification {
                             + "have the same submodel element type as specified in type "
                             + "value list element.")));
       }
-      if (!(!((that.getValue().isPresent())
-              && (that.getTypeValueListElement() == AasSubmodelElements.PROPERTY
-                  || that.getTypeValueListElement() == AasSubmodelElements.RANGE))
+      if (!(!(that.getTypeValueListElement() == AasSubmodelElements.PROPERTY
+              || that.getTypeValueListElement() == AasSubmodelElements.RANGE)
           || ((that.getValueTypeListElement().isPresent())
-              && propertiesOrRangesHaveValueType(
-                  that.getValue().orElse(null), that.getValueTypeListElement().orElse(null))))) {
+              && ((!that.getValue().isPresent())
+                  || propertiesOrRangesHaveValueType(
+                      that.getValue().orElse(null),
+                      that.getValueTypeListElement().orElse(null)))))) {
         errorStream =
             Stream.<Reporting.Error>concat(
                 errorStream,


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta f9cbdb3],
* [aas-core-codegen b14237b] and
* [aas-core3.0-testgen 5a705a0b].

Notably, we propagate the fix for AASd-109 where we change the invariant such that it checks for the consistency among properties even when a ``value`` property is missing.

[aas-core-meta f9cbdb3]: https://github.com/aas-core-works/aas-core-meta/commit/f9cbdb3
[aas-core-codegen b14237b]: https://github.com/aas-core-works/aas-core-codegen/commit/b14237b
[aas-core3.0-testgen 5a705a0b]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/5a705a0b