### PR TITLE
Fix workflow for dev_scripts CI

### DIFF
--- a/.github/workflows/ci-for-dev-scripts.yml
+++ b/.github/workflows/ci-for-dev-scripts.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install -e _dev_scripts --group _dev_scripts/pyproject.toml:dev
+          pip3 install --group dev_scripts/pyproject.toml:dev -e dev_scripts
 
       - name: Run checks
         run: |
-          python3 _dev_scripts/continuous_integration_of_dev_scripts/precommit.py
+          python3 dev_scripts/continuous_integration_of_dev_scripts/precommit.py


### PR DESCRIPTION
The workflow to call the CI for our dev_scripts contained some errors 
wrt. to the pip installation call and the path of the dev_scripts. We fix 
the call and the paths accordingly.