### PR TITLE
Fix missing escape in RFC2396 validation

### DIFF
--- a/dev_scripts/semantic-patching/src/main/java/aas_core_works/PatchVerification.java
+++ b/dev_scripts/semantic-patching/src/main/java/aas_core_works/PatchVerification.java
@@ -79,7 +79,8 @@ public class PatchVerification {
       return;
     }
 
-    VariableDeclarator expectedPatternDecl = null;
+    VariableDeclarator serverDecl = null;
+    VariableDeclarator uriReferenceDecl = null;
     ReturnStmt expectedReturnStmt = null;
 
     for (Statement statement : constructMethod.getBody().get().getStatements()) {
@@ -96,7 +97,10 @@ public class PatchVerification {
 
           if (expression.toString().equals(
                   "String uriReference = \"^(\" + absoluteuri + \"|\" + relativeuri + \")?(#\" + fragment + \")?$\"")) {
-            expectedPatternDecl = varDeclExpr.getVariable(0);
+            uriReferenceDecl = varDeclExpr.getVariable(0);
+          } else if (expression.toString().equals(
+                  "String server = \"((\" + userinfo + \"@)?\" + hostport + \")?\"")) {
+            serverDecl = varDeclExpr.getVariable(0);
           }
         }
       } else if (statement.isReturnStmt()) {
@@ -108,7 +112,18 @@ public class PatchVerification {
       }
     }
 
-    if (expectedPatternDecl == null) {
+    if (serverDecl == null) {
+      System.err.println(
+          "The constructMatchesRfc2396 lacks the "
+              + "String server = \"((\" + userinfo + \"@)?\" + hostport + \")?\""
+              + "statement in "
+              + sourcePath
+      );
+      System.exit(1);
+      return;
+    }
+
+    if (uriReferenceDecl == null) {
       System.err.println(
           "The constructMatchesRfc2396 lacks the "
               + "'String uriReference = \"^(\" + absoluteuri + \"|\" + relativeuri + \")?(#\" + fragment + \")?$\"' "
@@ -128,8 +143,13 @@ public class PatchVerification {
       return;
     }
 
-    expectedPatternDecl.setInitializer(
-      "\"(\" + absoluteuri + \"|\" + relativeuri + \")?(#\" + fragment + \")?\""
+    // NOTE (empwilli): we take care to also escape # and @ characters; these
+    // carry special meaning in Automaton.
+    serverDecl.setInitializer(
+      "\"((\" + userinfo + \"\\\\@)?\" + hostport + \")?\""
+    );
+    uriReferenceDecl.setInitializer(
+      "\"(\" + absoluteuri + \"|\" + relativeuri + \")?(\\\\#\" + fragment + \")?\""
     );
 
     expectedReturnStmt.setExpression(

--- a/src/main/java/aas_core/aas3_0/verification/Verification.java
+++ b/src/main/java/aas_core/aas3_0/verification/Verification.java
@@ -181,7 +181,7 @@ public class Verification {
     String host = "(" + hostname + "|" + ipv4address + ")";
     String port = "[0-9]*";
     String hostport = host + "(:" + port + ")?";
-    String server = "((" + userinfo + "@)?" + hostport + ")?";
+    String server = "((" + userinfo + "\\@)?" + hostport + ")?";
     String regName = "(" + unreserved + "|" + escaped + "|[$,;:@&=+])+";
     String authority = "(" + server + "|" + regName + ")";
     String netPath = "//" + authority + "(" + absPath + ")?";
@@ -196,7 +196,7 @@ public class Verification {
     String relSegment = "(" + unreserved + "|" + escaped + "|[;@&=+$,])+";
     String relPath = relSegment + "(" + absPath + ")?";
     String relativeuri = "(" + netPath + "|" + absPath + "|" + relPath + ")(\\?" + query + ")?";
-    String uriReference = "(" + absoluteuri + "|" + relativeuri + ")?(#" + fragment + ")?";
+    String uriReference = "(" + absoluteuri + "|" + relativeuri + ")?(\\#" + fragment + ")?";
     return new RegExp(uriReference).toAutomaton();
   }
 


### PR DESCRIPTION
The regex dialect used by the dk.brics RegEx language differs in some
details from Java regex. In particular, '#' and '@' characters carry
special meaning and must be escaped, as well. In this PR we adapt the 
semantic patching and verification code accordingly.